### PR TITLE
Remove DSK and TYP from list of Link-file only opcode

### DIFF
--- a/Source/a65816_Link.c
+++ b/Source/a65816_Link.c
@@ -640,14 +640,17 @@ static int Link65c816Segment(struct omf_project *current_omfproject, struct omf_
 }
 
 
-/***************************************************************/
-/*  IsLinkFile() :  Determine if a Source file is a File Link. */
-/***************************************************************/
+/************************************************************************/
+/*  IsLinkFile() :  Determine if the source file is a link file.        */
+/*  IsLinkFile() :  Détermine si un fichier Source est un fichier Link. */
+/************************************************************************/
 static int IsLinkFile(struct source_file *master_file)
 {
     int found = 0;
     struct source_line *current_line = NULL;
-    char *opcode_link[] = {"DSK","TYP","AUX","XPL","ASM","KND","ALI","LNA","SNA","BSZ",NULL};      /* Opcodes exclusive to a File Link */
+    /* Opcodes exclusive to link files  */
+    /* Opcode exclusifs au fichier Link */
+    char *opcode_link[] = {"AUX","XPL","ASM","KND","ALI","LNA","SNA","BSZ",NULL};      
 
     /* Valid File? */
     if(master_file->first_line == NULL)


### PR DESCRIPTION
- Yes, I put some French comments back in because I don't understand the need to remove them and the original translations weren't even good.