### PR TITLE
fix regression - replace missing initialization for `is_reloc_rtn`

### DIFF
--- a/Source/Dc_Library.c
+++ b/Source/Dc_Library.c
@@ -3931,6 +3931,7 @@ int64_t EvalExpressionAsInteger(char *expression_param, char *buffer_error_rtn, 
 
     /* Init */
     strcpy(buffer_error_rtn,"");
+    *is_reloc_rtn = 0;
     *byte_count_rtn = (BYTE)(current_line->nb_byte - 1);   /* Size of the Operand */
     *expression_address_rtn = 0xFFFFFFFF;        /* This is not a long address */
     is_pea_opcode = current_line->opcode_byte == 0xF4 /*PEA*/;

--- a/Source/version.h
+++ b/Source/version.h
@@ -1,3 +1,3 @@
 #ifndef MERLIN_VERSION
-#define MERLIN_VERSION "v1.1.9"
+#define MERLIN_VERSION "v1.1.10"
 #endif


### PR DESCRIPTION
This is a fix for this issue: https://github.com/lroathe/merlin32/issues/5

A comparison to the original Merlin32 1.0 source shows that the init section
used to contain this line.  It should be set to 0 every time the function is
called.

