### PR TITLE
update BuildAbsolutePath to correctly set folder_path and file_path_rtn to the expanded full path

### DIFF
--- a/Source/Dc_Library.c
+++ b/Source/Dc_Library.c
@@ -5181,7 +5181,7 @@ void BuildAbsolutePath(char *file_name, char *folder_path, char *file_path_rtn)
     }
 
     /* append a trailing separator */
-    if (strlen(folder_path) < 1022) {
+    if (strlen(folder_path) <= 1022) {
         /* point to the \0 terminator */
         buf_ptr = folder_path + strlen(folder_path);
 

--- a/Source/Dc_Library.c
+++ b/Source/Dc_Library.c
@@ -5174,8 +5174,32 @@ void BuildAbsolutePath(char *file_name, char *folder_path, char *file_path_rtn)
     strcpy(file_path_rtn,folder_path);
     if(file_name[0] == '/' || file_name[0] == '\\')
         strcat(file_path_rtn,&file_name[1]);
-    else
-        strcat(file_path_rtn,file_name);
+    else {
+        /* expand the path using realpath */
+        char buf[4096];
+        char *last_ptr = strncpy(&buf[0], folder_path, sizeof(buf));
+        if (last_ptr > &buf[0]) {
+            if (*(last_ptr-1) != '/' && *(last_ptr-1) != '\\') {
+                *last_ptr = '/';
+                ++last_ptr;
+                *last_ptr = '\0';
+            }
+
+            last_ptr = strcat(last_ptr, file_name);
+
+            char * real_ptr = realpath(&buf[0], file_path_rtn);
+            if (file_path_rtn == real_ptr) {
+                return;
+            } else {
+                /* fallback to original behavior */
+                strcat(file_path_rtn,file_name);
+            }
+
+        } else {
+            /* fallback to original behavior */
+            strcat(file_path_rtn,file_name);
+        }
+    }
 }
 
 

--- a/Source/Dc_Library.c
+++ b/Source/Dc_Library.c
@@ -1334,7 +1334,7 @@ void my_Memory(int code, void *data, void *value, struct omf_segment *current_om
 
 
 /****************************************************/
-/*  my_stricmp() : Case insensitive string compare. */
+/*  my_intcmp() : Compare integers and return if less-than, greater, or equal */
 /****************************************************/
 int my_intcmp(int int1, int int2)
 {
@@ -1347,7 +1347,7 @@ int my_intcmp(int int1, int int2)
 }
 
 /******************************************************/
-/*  my_stri64cmp() : Case insensitive string compare. */
+/*  my_int64cmp() : Compare integers and return if less-than, greater, or equal */
 /******************************************************/
 int my_int64cmp(int64_t int1, int64_t int2)
 {
@@ -1483,7 +1483,7 @@ char *GetFileProperCasePath(char *file_path_arg)
     if(file_path_arg[0] != '/')
     {
         /* Current directory */
-        getcwd(folder_current,1024);
+        getcwd(folder_current, sizeof(folder_current));
         if(strlen(folder_current) > 0)
             if(folder_current[strlen(folder_current)-1] != '/')
                 strcat(folder_current,"/");
@@ -5163,6 +5163,10 @@ int IsProdosName(char *file_name)
 /***********************************************************/
 void BuildAbsolutePath(char *file_name, char *folder_path, char *file_path_rtn)
 {
+    char buf[4096];
+    char *buf_ptr;
+    char *real_ptr;
+
     /* Init */
     strcpy(file_path_rtn,file_name);
 
@@ -5170,31 +5174,45 @@ void BuildAbsolutePath(char *file_name, char *folder_path, char *file_path_rtn)
     if(file_name[1] == ':' || file_name[0] == '/')
         return;
 
+    /* empty folder_path gets cwd */
+    if (strlen(folder_path) == 0) {
+        getcwd(folder_path, 1023);
+        folder_path[1023] = '\0';
+    }
+
+    /* append a trailing separator */
+    if (strlen(folder_path) < 1022) {
+        /* point to the \0 terminator */
+        buf_ptr = folder_path + strlen(folder_path);
+
+        /* add trailing slash to folder_path if missing */
+        if (*(buf_ptr-1) != '/' && *(buf_ptr-1) != '\\') {
+            *buf_ptr = *FOLDER_SEPARATOR;
+            *++buf_ptr = '\0';
+        }
+    }
+
     /* Folder Path + File Name */
     strcpy(file_path_rtn,folder_path);
+
     if(file_name[0] == '/' || file_name[0] == '\\')
-        strcat(file_path_rtn,&file_name[1]);
+        strcat(file_path_rtn, &file_name[1]);
     else {
-        /* expand the path using realpath */
-        char buf[4096];
-        char *last_ptr = strncpy(&buf[0], folder_path, sizeof(buf));
-        if (last_ptr > &buf[0]) {
-            if (*(last_ptr-1) != '/' && *(last_ptr-1) != '\\') {
-                *last_ptr = '/';
-                ++last_ptr;
-                *last_ptr = '\0';
-            }
+        /* expand and correct the path using stdlib realpath */
+        char *buf_ptr = strncpy(&buf[0], folder_path, sizeof(buf));
 
-            last_ptr = strcat(last_ptr, file_name);
+        if (buf_ptr == &buf[0] && my_stricmp(buf_ptr, folder_path) == 0) {
+            /* append filename */
+            strcat(&buf[0], file_name);
 
+            /* set the corrected full path */
             char * real_ptr = realpath(&buf[0], file_path_rtn);
             if (file_path_rtn == real_ptr) {
-                return;
+                return; /* bam! */
             } else {
                 /* fallback to original behavior */
                 strcat(file_path_rtn,file_name);
             }
-
         } else {
             /* fallback to original behavior */
             strcat(file_path_rtn,file_name);

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -12,16 +12,24 @@
 #       make PREFIX=/opt/merlin32
 #     The default PREFIX is /usr/local.
 
+
+CFLAGS_DEBUG=-g
+CFLAGS_OPT=-O3
+
+TARGET=merlin32$(EXE_EXT)
+CFLAGS+=-Wall -DMACRO_DIR=\"$(MACRO_DIR)\"
+BIN_CONFIG=../Scripts/config.sh
+
 ifeq ($(OS),Windows_NT)
     ifndef PREFIX
-	PREFIX=$(USERPROFILE)/Applications/Merlin32
+    PREFIX=$(USERPROFILE)/Applications/Merlin32
     endif
     MERLIN_BIN=$(PREFIX)/bin
     MACRO_DIR=$(PREFIX)/asminc
     EXE_EXT=.exe
 else
     ifndef PREFIX
-	PREFIX=/usr/local
+    PREFIX=/usr/local
     endif
     MERLIN_BIN=$(PREFIX)/bin
     MACRO_DIR=$(PREFIX)/share/merlin32/asminc
@@ -46,18 +54,26 @@ else
             endif
         endif
     endif
-        
+
+    ifeq ($(MAKECMDGOALS),debug)
+        override CFLAGS+=$(CFLAGS_DEBUG)
+    else
+        override CFLAGS+=$(CFLAGS_OPT)
+    endif
+
 endif
 
-TARGET=merlin32$(EXE_EXT)
-CFLAGS+=-O3 -Wall -DMACRO_DIR=\"$(MACRO_DIR)\"
-BIN_CONFIG=../Scripts/config.sh
+
 
 SOURCES = a65816_Code.c a65816_Cond.c a65816_Data.c a65816_File.c \
 	  a65816_Line.c a65816_Link.c a65816_Lup.c a65816_Macro.c a65816_OMF.c \
 	  Dc_Library.c Main.c 
 
 OBJECTS=$(SOURCES:.c=.o)
+
+all: $(TARGET)
+
+debug: $(TARGET)
 
 $(TARGET): $(OBJECTS) $(BIN_CONFIG)
 	$(CC) $(OBJECTS) -o $@


### PR DESCRIPTION
Ok, this is working now.  The reason I changed this is because merlin32 failed when I was trying to link together files from different directories using relative paths in my link file, like ../lib/math.s ../lib/string.s.  Merlin was being lazy about rectifying partial relative paths, just concatenating them together and hoping for the best.  I can't blame the Olivier. This is one of the most annoying areas of this kind of programming.

Using stdlib you can just get the fullpath using getcwd and realpath. The best way is to get the fixed full paths early, that way the correct paths percolate outward as more files are built using directory paths derived from them. 

This change should be resilient to being run from different folder locations, and hopefully not break anyone's existing workflows.  I understand there is still a difference between being correct and inconveniencing everybody. ymmv